### PR TITLE
Small changes to make bulb more downstream-friendly

### DIFF
--- a/yeelight/__init__.py
+++ b/yeelight/__init__.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-from yeelight.main import Bulb
+from yeelight.main import Bulb, BulbType, BulbException
 from yeelight.flow import (
         Flow,
         HSVTransition,

--- a/yeelight/main.py
+++ b/yeelight/main.py
@@ -169,7 +169,7 @@ class Bulb(object):
         :param str method:  The name of the method to send.
         :param list params: The list of parameters for the method.
 
-        :raises BulbException: When bulb indicates error condition.
+        :raises BulbException: When the bulb indicates an error condition.
         :returns: The response from the bulb.
         """
         command = {

--- a/yeelight/main.py
+++ b/yeelight/main.py
@@ -137,7 +137,7 @@ class Bulb(object):
         """
         if not self._last_properties:
             return BulbType.Unknown
-        if not any([self.last_properties[name] for name in ['ct', 'rgb', 'hue', 'sat']]):
+        if not all(name in self.last_properties for name in ['ct', 'rgb', 'hue', 'sat']):
             return BulbType.White
         else:
             return BulbType.Color

--- a/yeelight/main.py
+++ b/yeelight/main.py
@@ -42,7 +42,7 @@ class BulbException(Exception):
 
 class BulbType(Enum):
     """
-    BulbType enum specifies bulb's type, either White or Color,
+    The BulbType enum specifies bulb's type, either White or Color,
     or Unknown if the properties have not been fetched yet.
     """
     Unknown = -1
@@ -157,7 +157,7 @@ class Bulb(object):
         ]
         response = self.send_command("get_prop", requested_properties)
         properties = response["result"]
-        properties = [None if x == '' else x for x in properties]
+        properties = [x if x else None for x in properties]
 
         self._last_properties = dict(zip(requested_properties, properties))
         return self._last_properties
@@ -169,7 +169,7 @@ class Bulb(object):
         :param str method:  The name of the method to send.
         :param list params: The list of parameters for the method.
 
-        :raises BulbException: on error response from the bulb
+        :raises BulbException: When bulb indicates error condition.
         :returns: The response from the bulb.
         """
         command = {

--- a/yeelight/main.py
+++ b/yeelight/main.py
@@ -197,7 +197,12 @@ class Bulb(object):
         # so we want to make sure that we read until we see an actual response.
         response = None
         while response is None:
-            data = self._socket.recv(16 * 1024)
+            try:
+                data = self._socket.recv(16 * 1024)
+            except socket.error:
+                # Some error occured like above, let's close and try later again..
+                self.__socket.close()
+                self.__socket = None
             for line in data.split(b"\r\n"):
                 if not line:
                     continue

--- a/yeelight/main.py
+++ b/yeelight/main.py
@@ -133,7 +133,7 @@ class Bulb(object):
         When trying to access before properties are known, the bulb type is unknown.
 
         :rtype: BulbType
-        :return: bulbs type
+        :return: The bulb's type.
         """
         if not self._last_properties:
             return BulbType.Unknown


### PR DESCRIPTION
This commit makes using the class much nicer for downstream by:
1. Non-existing properties are set to None instead of keeping them as ''.
2. Adds logger to allow enabling verbose messaging trace.
3. Bulb errors are raised as BulbExceptions, e.g., if user tries to set color on bulb not supporting the feature.
4. bulb_type allows distinguishing between color and white models.