### PR TITLE
Bulb type detection fixed

### DIFF
--- a/yeelight/main.py
+++ b/yeelight/main.py
@@ -221,7 +221,7 @@ class Bulb(object):
         """
         if not self._last_properties:
             return BulbType.Unknown
-        if not all(name in self.last_properties for name in ['ct', 'rgb', 'hue', 'sat']):
+        if all(name in self.last_properties and self.last_properties[name] is None for name in ['ct', 'rgb', 'hue', 'sat']):
             return BulbType.White
         else:
             return BulbType.Color


### PR DESCRIPTION

The property names are always available (if requested). The values needs to be checked. As far as this issue is fixed the color wheel will disappear for white bulbs at Home Assistant again.

```
Bulb<192.168.130.45:55443, type=BulbType.Unknown> > {'method': 'get_prop', 'id': 0, 'params': ['power', 'bright', 'ct', 'rgb', 'hue', 'sat', 'color_mode', 'flowing', 'delayoff', 'music_on', 'name']}
Bulb<192.168.130.45:55443, type=BulbType.Unknown> < {'result': ['on', '62', '4000', '16777214', '359', '100', '1', '0', '0', '0', ''], 'id': 0}
Bulb<192.168.130.45:55443, type=BulbType.Color> > {'method': 'get_prop', 'id': 1, 'params': ['power', 'bright', 'ct', 'rgb', 'hue', 'sat', 'color_mode', 'flowing', 'delayoff', 'music_on', 'name']}
Bulb<192.168.130.45:55443, type=BulbType.Color> < {'result': ['on', '62', '4000', '16777214', '359', '100', '1', '0', '0', '0', ''], 'id': 1}
-> Bulb type: BulbType.Color
-> Last properties: {'rgb': '16777214', 'power': 'on', 'music_on': '0', 'flowing': '0', 'delayoff': '0', 'bright': '62', 'name': None, 'sat': '100', 'ct': '4000', 'color_mode': '1', 'hue': '359'}

Bulb<192.168.130.27:55443, type=BulbType.Unknown> > {'method': 'get_prop', 'id': 0, 'params': ['power', 'bright', 'ct', 'rgb', 'hue', 'sat', 'color_mode', 'flowing', 'delayoff', 'music_on', 'name']}
Bulb<192.168.130.27:55443, type=BulbType.Unknown> < {'result': ['on', '100', '', '', '', '', '2', '0', '0', '', ''], 'id': 0}
Bulb<192.168.130.27:55443, type=BulbType.White> > {'method': 'get_prop', 'id': 1, 'params': ['power', 'bright', 'ct', 'rgb', 'hue', 'sat', 'color_mode', 'flowing', 'delayoff', 'music_on', 'name']}
Bulb<192.168.130.27:55443, type=BulbType.White> < {'result': ['on', '100', '', '', '', '', '2', '0', '0', '', ''], 'id': 1}
-> Bulb type: BulbType.White
-> Last properties: {'rgb': None, 'power': 'on', 'music_on': None, 'flowing': '0', 'delayoff': '0', 'bright': '100', 'name': None, 'sat': None, 'ct': None, 'color_mode': '2', 'hue': None}
```